### PR TITLE
Stream recv flow-control bounded

### DIFF
--- a/examples/dataStream.nim
+++ b/examples/dataStream.nim
@@ -65,8 +65,7 @@ when isMainModule:
       await streamChunks(client, "/foo")
 
   waitFor main()
-  doAssert dataSentSize == dataSize
-  #doAssert dataRecvSize == dataSize
-  doAssert dataRecvSize > 0
   doAssert not hasPendingOperations()
+  doAssert dataSentSize == dataSize
+  doAssert dataRecvSize == dataSize
   echo "ok"

--- a/examples/localServer.nim
+++ b/examples/localServer.nim
@@ -27,8 +27,11 @@ proc processStream(strm: ClientStream) {.async.} =
     await strm.recvHeaders(data)
     await strm.sendHeaders(
       newSeqRef(@[(":status", "200")]),
-      finish = strm.recvEnded
+      finish = false
     )
+    if strm.recvEnded:
+      data[] = "Hello world!"
+      await strm.sendBody(data, finish = true)
     while not strm.recvEnded:
       data[].setLen 0
       await strm.recvBody(data)

--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -25,7 +25,7 @@ export
   recvHeaders,
   recvEnded,
   recvBody,
-  #sendHeaders,
+  sendHeaders,
   sendBody,
   ClientStream,
   ClientContext,
@@ -105,18 +105,6 @@ proc sendHeaders*(
     client.hpackEncode(headers[], "content-length", $contentLen)
   let finish = contentLen == 0
   await strm.sendHeaders(headers, finish)
-
-proc sendHeaders*(
-  strm: ClientStream,
-  headers: ref seq[(string, string)],
-  finish: bool
-) {.async.} =
-  template client: untyped = strm.client
-  var henc = new(seq[byte])
-  henc[] = newSeq[byte]()
-  for (n, v) in headers[]:
-    client.hpackEncode(henc[], n, v)
-  await strm.sendHeaders(henc, finish)
 
 type
   Payload* = ref object

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1063,7 +1063,7 @@ proc sendBodyNaked(
           newStrmError(stream.errCodeOrDefault errStreamClosed)
         await client.peerWindowUpdateSig.waitFor()
     let peerWindow = min(client.peerWindow, stream.peerWindow)
-    dataIdxB = min(dataIdxA+min(peerWindow, L), L)
+    dataIdxB = min(dataIdxA+min(peerWindow, stgInitialMaxFrameSize.int), L)
     var frm = newFrame()
     frm.setTyp frmtData
     frm.setSid stream.id.FrmSid

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -25,7 +25,7 @@ export
   withStream,
   recvHeaders,
   recvBody,
-  #sendHeaders,
+  sendHeaders,
   sendBody,
   recvEnded,
   ClientStream,
@@ -165,15 +165,3 @@ proc sendHeaders*(
     client.hpackEncode(headers[], "content-length", $contentLen)
   let finish = contentLen <= 0
   await strm.sendHeaders(headers, finish)
-
-proc sendHeaders*(
-  strm: ClientStream,
-  headers: ref seq[(string, string)],
-  finish: bool
-) {.async.} =
-  template client: untyped = strm.client
-  var henc = new(seq[byte])
-  henc[] = newSeq[byte]()
-  for (n, v) in headers[]:
-    client.hpackEncode(henc[], n, v)
-  await strm.sendHeaders(henc, finish)

--- a/src/hyperx/testutils.nim
+++ b/src/hyperx/testutils.nim
@@ -120,6 +120,18 @@ proc recv*(tc: TestClientContext, headers: string) {.async.} =
   await tc.client.putRecvTestData frm1.s
   tc.sid += 2
 
+proc recv*(
+  tc: TestClientContext,
+  headers: string,
+  sid: int,
+  finish: bool
+) {.async.} =
+  var frm1 = frame(frmtHeaders, sid.FrmSid, @[frmfEndHeaders])
+  if finish:
+    frm1.flags.incl frmfEndStream
+  frm1.add hencode(tc, headers).toBytes
+  await tc.client.putRecvTestData frm1.s
+
 proc recv*(tc: TestClientContext, s: seq[byte]) {.async.} =
   await tc.client.putRecvTestData s
 

--- a/tests/functional/tconcurrentdata.nim
+++ b/tests/functional/tconcurrentdata.nim
@@ -48,7 +48,6 @@ proc send(strm: ClientStream, req: Req) {.async.} =
 proc recv(strm: ClientStream, req: Req) {.async.} =
   var data = newStringref()
   await strm.recvHeaders(data)
-  let exptLen = req.headers.raw[].len + req.data.s[].len
   doAssert data[] == ":status: 200\r\n"
   data[].setLen 0
   while not strm.recvEnded:

--- a/tests/functional/tserver.nim
+++ b/tests/functional/tserver.nim
@@ -1,69 +1,26 @@
 {.define: ssl.}
 
 from std/os import getEnv
-import std/deques
 import std/asyncdispatch
 import ../../src/hyperx/server
-import ../../src/hyperx/signal
 import ./tutils
 
 const certFile = getEnv "HYPERX_TEST_CERTFILE"
 const keyFile = getEnv "HYPERX_TEST_KEYFILE"
 
-type Channel = ref object
-  s: Deque[ref string]
-  sig: SignalAsync
-
-proc newChannel: Channel =
-  new result
-  result = Channel(
-    s: initDeque[ref string](),
-    sig: newSignal()
-  )
-
-proc wait(ch: Channel) {.async.} =
-  if ch.s.len > 0:
-    return
-  try:
-    await ch.sig.waitFor()
-  except SignalClosedError:
-    discard
-
-proc add(ch: Channel, data: ref string) =
-  ch.s.addFirst(data)
-  ch.sig.trigger()
-
-proc ended(ch: Channel): bool =
-  result = ch.sig.isClosed and ch.s.len == 0
-
-proc send(strm: ClientStream, channel: Channel) {.async.} =
-  await strm.sendHeaders(
-    newSeqRef(@[(":status", "200")]),
-    finish = channel.ended
-  )
-  while not channel.ended:
-    await channel.wait()
-    while channel.s.len > 0:
-      let data = channel.s.popLast()
-      await strm.sendBody(data, finish = channel.ended)
-
-proc recv(strm: ClientStream, channel: Channel) {.async.} =
-  let data = newStringRef()
-  await strm.recvHeaders(data)
-  channel.add(data)
-  while not strm.recvEnded:
-    let data = newStringRef()
-    await strm.recvBody(data)
-    channel.add(data)
-  channel.sig.close()
-
 proc processStream(strm: ClientStream) {.async.} =
   withStream strm:
-    let channel = newChannel()
-    let sendFut = strm.send(channel)
-    let recvFut = strm.recv(channel)
-    await sendFut
-    await recvFut
+    let data = newStringRef()
+    await strm.recvHeaders(data)
+    await strm.sendHeaders(
+      newSeqRef(@[(":status", "200")]),
+      finish = false
+    )
+    await strm.sendBody(data, finish = strm.recvEnded)
+    while not strm.recvEnded:
+      data[].setLen 0
+      await strm.recvBody(data)
+      await strm.sendBody(data, finish = strm.recvEnded)
   #GC_fullCollect()
 
 proc processStreamHandler(strm: ClientStream) {.async.} =

--- a/tests/testclient.nim
+++ b/tests/testclient.nim
@@ -8,6 +8,8 @@ import ../src/hyperx/client
 import ../src/hyperx/testutils
 import ../src/hyperx/frame
 import ../src/hyperx/errors
+from ../src/hyperx/clientserver import
+  stgWindowSize, stgInitialWindowSize
 
 const
   userAgent = "Nim-HyperX/0.1"
@@ -33,9 +35,10 @@ proc checkHandshake(tc: TestClientContext) {.async.} =
   let frm1 = await tc.sent()
   doAssert frm1.typ == frmtSettings
   doAssert frm1.sid == frmSidMain
-  let frm2 = await tc.sent()
-  doAssert frm2.typ == frmtWindowUpdate
-  doAssert frm2.sid == frmSidMain
+  if stgWindowSize > stgInitialWindowSize:
+    let frm2 = await tc.sent()
+    doAssert frm2.typ == frmtWindowUpdate
+    doAssert frm2.sid == frmSidMain
 
 proc checkTableSizeAck(tc: TestClientContext) {.async.} =
   let frm1 = await tc.sent()

--- a/tests/testserver.nim
+++ b/tests/testserver.nim
@@ -8,6 +8,8 @@ import ../src/hyperx/server
 import ../src/hyperx/testutils
 import ../src/hyperx/frame
 import ../src/hyperx/errors
+from ../src/hyperx/clientserver import
+  stgWindowSize, stgInitialWindowSize
 
 func toBytes(s: string): seq[byte] =
   result = newSeq[byte]()
@@ -31,9 +33,10 @@ proc checkHandshake(tc: TestClientContext) {.async.} =
   let frm1 = await tc.sent()
   doAssert frm1.typ == frmtSettings
   doAssert frm1.sid == frmSidMain
-  let frm2 = await tc.sent()
-  doAssert frm2.typ == frmtWindowUpdate
-  doAssert frm2.sid == frmSidMain
+  if stgWindowSize > stgInitialWindowSize:
+    let frm2 = await tc.sent()
+    doAssert frm2.typ == frmtWindowUpdate
+    doAssert frm2.sid == frmSidMain
 
 testAsync "simple request":
   var checked = false

--- a/tests/testserver.nim
+++ b/tests/testserver.nim
@@ -83,3 +83,122 @@ testAsync "simple request":
       doAssert frmfEndStream in frm2.flags
       checked = true
   doAssert checked
+
+testAsync "exceed window size":
+  var check1 = false
+  var check2 = false
+  const headers =
+    ":method: GET\r\n" &
+    ":path: /\r\n" &
+    ":scheme: https\r\n" &
+    "foo: foo\r\n"
+  var server = newServer(
+    "foo.bar", Port 443, "./cert", "./key"
+  )
+  proc sender(tc: TestClientContext) {.async.} =
+    tc.sid += 2
+    let strmId = tc.sid
+    await tc.recv(headers, strmId, finish = false)
+    var text = ""
+    for _ in 0 .. frmsMaxFrameSize.int-1:
+      text.add 'a'
+    var frmData1 = frame(frmtData, strmId.FrmSid)
+    frmData1.add text.toBytes
+    var sentCount = 0
+    while sentCount <= stgWindowSize.int * 2:
+      if not tc.client.isConnected:  # errored out
+        break
+      await tc.recv frmData1.s
+      sentCount += text.len
+    doAssert not tc.client.isConnected
+
+  withServer server:
+    let client1 = await server.recvClient()
+    let tc1 = newTestClient(client1)
+    await tc1.recv(preface)
+    withClient tc1.client:
+      await tc1.checkHandshake()
+      let senderFut = tc1.sender()
+      let strm = await client1.recvStream()
+      try:
+        withStream strm:
+          await senderFut
+          var data = newStringRef()
+          await strm.recvHeaders(data)
+          var consumed = 0
+          try:
+            while not strm.recvEnded:
+              data[].setLen 0
+              await strm.recvBody(data)
+              consumed += data[].len
+            doAssert false
+          except HyperxConnError as err:
+            doAssert "FLOW_CONTROL_ERROR" in err.msg
+            # make sure we consume all pending data?
+            doAssert consumed == stgWindowSize.int
+            check1 = true
+            raise err
+        doAssert false
+      except HyperxConnError as err:
+        doAssert "FLOW_CONTROL_ERROR" in err.msg
+        check2 = true
+  doAssert check1
+  doAssert check2
+
+testAsync "consume window size":
+  var check1 = false
+  const headers =
+    ":method: GET\r\n" &
+    ":path: /\r\n" &
+    ":scheme: https\r\n" &
+    "foo: foo\r\n"
+  var server = newServer(
+    "foo.bar", Port 443, "./cert", "./key"
+  )
+  proc sender(tc: TestClientContext) {.async.} =
+    tc.sid += 2
+    let strmId = tc.sid
+    await tc.recv(headers, strmId, finish = false)
+    var text = ""
+    for _ in 0 .. frmsMaxFrameSize.int-1:
+      text.add 'a'
+    var frmData1 = frame(frmtData, strmId.FrmSid)
+    frmData1.add text.toBytes
+    var sentCount = 0
+    while true:
+      if sentCount+text.len > stgWindowSize.int:
+        break
+      doAssert tc.client.isConnected
+      await tc.recv frmData1.s
+      sentCount += text.len
+    doAssert sentCount <= stgWindowSize.int
+    let frmEnd = frame(frmtData, strmId.FrmSid, @[frmfEndStream])
+    frmEnd.add toOpenArray(text.toBytes, 0, stgWindowSize.int-sentCount-1)
+    await tc.recv frmEnd.s
+
+  withServer server:
+    let client1 = await server.recvClient()
+    let tc1 = newTestClient(client1)
+    await tc1.recv(preface)
+    withClient tc1.client:
+      await tc1.checkHandshake()
+      let senderFut = tc1.sender()
+      let strm = await client1.recvStream()
+      withStream strm:
+        await senderFut
+        var data = newStringRef()
+        await strm.recvHeaders(data)
+        var consumed = 0
+        while not strm.recvEnded:
+          data[].setLen 0
+          await strm.recvBody(data)
+          consumed += data[].len
+        doAssert consumed == stgWindowSize.int
+        await strm.sendHeaders(
+          status = 200,
+          contentType = "text/plain",
+          contentLen = 0
+        )
+        check1 = true
+  doAssert check1
+


### PR DESCRIPTION
fixes #6 

- [x] Enable flow-control (remove high limit)
- [x] Move window update to recvBody
- [x] Add window size defined value
- [x] flow-control error on recv window size exceeded
- [ ] Add functional concurrent tests that go over the window size