### PR TITLE
Do not allow sending headers/data on closed streams

### DIFF
--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -12,6 +12,7 @@ import std/asyncnet
 import ./clientserver
 import ./errors
 import ./utils
+import ./stream
 
 when defined(hyperxTest):
   import ./testsocket
@@ -93,6 +94,8 @@ proc sendHeaders*(
   contentLen = 0
 ) {.async.} =
   template client: untyped = strm.client
+  check strm.stream.state in strmStateHeaderAllowed,
+    newStrmError errStreamClosed
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()
   client.hpackEncode(headers[], ":method", $httpMethod)
@@ -107,7 +110,7 @@ proc sendHeaders*(
     client.hpackEncode(headers[], "content-type", contentType)
     client.hpackEncode(headers[], "content-length", $contentLen)
   let finish = contentLen == 0
-  await strm.sendHeaders(headers, finish)
+  await strm.sendHeadersImpl(headers, finish)
 
 type
   Payload* = ref object

--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -94,7 +94,7 @@ proc sendHeaders*(
   contentLen = 0
 ) {.async.} =
   template client: untyped = strm.client
-  check strm.stream.state in strmStateHeaderAllowed,
+  check strm.stream.state in strmStateHeaderSendAllowed,
     newStrmError errStreamClosed
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()

--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -94,8 +94,9 @@ proc sendHeaders*(
   contentLen = 0
 ) {.async.} =
   template client: untyped = strm.client
-  check strm.stream.state in strmStateHeaderSendAllowed,
-    newStrmError errStreamClosed
+  template stream: untyped = strm.stream
+  check stream.state in strmStateHeaderSendAllowed,
+    newErrorOrDefault(stream.error, newStrmError errStreamClosed)
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()
   client.hpackEncode(headers[], ":method", $httpMethod)

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1133,12 +1133,14 @@ proc sendHeaders*(
   headers: ref seq[(string, string)],
   finish: bool
 ) {.async.} =
-  check strm.stream.state in strmStateHeaderSendAllowed,
-    newStrmError errStreamClosed
+  template client: untyped = strm.client
+  template stream: untyped = strm.stream
+  check stream.state in strmStateHeaderSendAllowed,
+    newErrorOrDefault(stream.error, newStrmError errStreamClosed)
   var henc = new(seq[byte])
   henc[] = newSeq[byte]()
   for (n, v) in headers[]:
-    strm.client.hpackEncode(henc[], n, v)
+    client.hpackEncode(henc[], n, v)
   await strm.sendHeadersImpl(henc, finish)
 
 proc sendBodyNaked(

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1133,7 +1133,7 @@ proc sendHeaders*(
   headers: ref seq[(string, string)],
   finish: bool
 ) {.async.} =
-  check strm.stream.state in strmStateHeaderAllowed,
+  check strm.stream.state in strmStateHeaderSendAllowed,
     newStrmError errStreamClosed
   var henc = new(seq[byte])
   henc[] = newSeq[byte]()

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1158,7 +1158,7 @@ proc sendBodyNaked(
       while stream.peerWindow <= 0:
         await stream.peerWindowUpdateSig.waitFor()
       while client.peerWindow <= 0:
-        check stream.state != strmClosed,
+        check stream.state in strmStateDataSendAllowed,
           newErrorOrDefault(stream.error, newStrmError errStreamClosed)
         await client.peerWindowUpdateSig.waitFor()
     let peerWindow = min(client.peerWindow, stream.peerWindow)
@@ -1173,7 +1173,7 @@ proc sendBodyNaked(
     frm.s.add toOpenArray(data[], dataIdxA, dataIdxB-1)
     stream.peerWindow -= frm.payloadLen.int32
     client.peerWindow -= frm.payloadLen.int32
-    check stream.state != strmClosed,
+    check stream.state in strmStateDataSendAllowed,
       newErrorOrDefault(stream.error, newStrmError errStreamClosed)
     await client.write frm
     dataIdxA = dataIdxB

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -159,6 +159,8 @@ proc sendHeaders*(
   contentLen = -1
 ) {.async.} =
   template client: untyped = strm.client
+  check strm.stream.state in strmStateHeaderAllowed,
+    newStrmError errStreamClosed
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()
   client.hpackEncode(headers[], ":status", $status)
@@ -167,4 +169,4 @@ proc sendHeaders*(
   if contentLen > -1:
     client.hpackEncode(headers[], "content-length", $contentLen)
   let finish = contentLen <= 0
-  await strm.sendHeaders(headers, finish)
+  await strm.sendHeadersImpl(headers, finish)

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -159,8 +159,9 @@ proc sendHeaders*(
   contentLen = -1
 ) {.async.} =
   template client: untyped = strm.client
-  check strm.stream.state in strmStateHeaderSendAllowed,
-    newStrmError errStreamClosed
+  template stream: untyped = strm.stream
+  check stream.state in strmStateHeaderSendAllowed,
+    newErrorOrDefault(stream.error, newStrmError errStreamClosed)
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()
   client.hpackEncode(headers[], ":status", $status)

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -159,7 +159,7 @@ proc sendHeaders*(
   contentLen = -1
 ) {.async.} =
   template client: untyped = strm.client
-  check strm.stream.state in strmStateHeaderAllowed,
+  check strm.stream.state in strmStateHeaderSendAllowed,
     newStrmError errStreamClosed
   var headers = new(seq[byte])
   headers[] = newSeq[byte]()

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -56,6 +56,11 @@ const strmStateHeaderSendAllowed* = {
   strmHalfClosedRemote
 }
 
+const strmStateDataSendAllowed* = {
+  strmOpen,
+  strmHalfClosedRemote
+}
+
 func toStreamEvent*(frm: Frame): StreamEvent {.raises: [].} =
   case frm.typ
   of frmtData:
@@ -364,5 +369,10 @@ when isMainModule:
       for state in allStates - {strmInvalid}:
         let isValid = toNextStateSend(state, ev) != strmInvalid
         doAssert state in strmStateHeaderSendAllowed == isValid, $state & " " & $ev
+  block:
+    for ev in {seData, seDataEndStream}:
+      for state in allStates - {strmInvalid}:
+        let isValid = toNextStateSend(state, ev) != strmInvalid
+        doAssert state in strmStateDataSendAllowed == isValid, $state & " " & $ev
 
   echo "ok"

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -49,6 +49,13 @@ const frmStreamAllowed* = {
   frmtWindowUpdate
 }
 
+const strmStateHeaderAllowed* = {
+  strmIdle,
+  strmOpen,
+  strmReservedLocal,
+  strmHalfClosedRemote
+}
+
 func toStreamEvent*(frm: Frame): StreamEvent {.raises: [].} =
   case frm.typ
   of frmtData:
@@ -146,7 +153,7 @@ func toNextStateSend*(s: StreamState, e: StreamEvent): StreamState {.raises: [].
   of strmReservedLocal:
     case e
     of seHeaders: strmHalfClosedRemote
-    of seRstStream: strmClosed
+    of seHeadersEndStream, seRstStream: strmClosed
     of sePriority: strmReservedLocal
     else: strmInvalid
   of strmHalfClosedRemote:


### PR DESCRIPTION
An attempt to improve racy stream errors. So it's not possible to send any non-allowed frame after the stream is closed.