### PR TITLE
Improve stream closed state mismatch after sending RST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
           sleep 10s && \
           curl -JLO \"https://github.com/nitely/nim-hyperx/releases/download/v0.1.20/h2spec\" && \
           chmod +x ./h2spec && \
-          ./h2spec --tls --port 4443 --strict && \
-          ./h2spec --tls --port 4443 --strict && \
-          ./h2spec --tls --port 4443 --strict"
+          nimble h2spec && \
+          nimble h2spec && \
+          nimble h2spec"
     - name: Run h2load
       run: |
         docker pull nimlang/nim:${{ matrix.nim }}
@@ -77,5 +77,5 @@ jobs:
           (nimble serve2 &) && \
           sleep 10s && \
           apt install -y nghttp2-client && \
-          h2load -n100000 -c100 -m10 https://127.0.0.1:4443 | grep \"100000 2xx\" && \
-          h2load -n100000 -c10 -m1000 -t2 https://127.0.0.1:4443"
+          nimble h2load && \
+          nimble h2load2"

--- a/examples/localServer.nim
+++ b/examples/localServer.nim
@@ -8,7 +8,7 @@ import std/asyncdispatch
 import ../src/hyperx/server
 
 const localHost* = "127.0.0.1"
-const localPort* = Port 4443
+const localPort* = Port 8783
 const certFile = getEnv "HYPERX_TEST_CERTFILE"
 const keyFile = getEnv "HYPERX_TEST_KEYFILE"
 

--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -60,5 +60,14 @@ task functest, "Func test":
   exec "nim c -r -d:release tests/functional/tconcurrentdata.nim"
   exec "nim c -r -d:release tests/functional/tflowcontrol.nim"
 
+task h2spec, "h2spec test":
+  exec "./h2spec --tls --port 8783 --strict"
+
+task h2load, "h2load test":
+  exec "h2load -n100000 -c100 -m10 https://127.0.0.1:8783 | grep ""100000 2xx"""
+
+task h2load2, "h2load test":
+  exec "h2load -n100000 -c10 -m1000 -t2 https://127.0.0.1:8783"
+
 task docs, "Docs":
   exec "nim doc2 -o:./docs --project ./src/hyperx.nim"

--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -64,7 +64,7 @@ task h2spec, "h2spec test":
   exec "./h2spec --tls --port 8783 --strict"
 
 task h2load, "h2load test":
-  exec "h2load -n100000 -c100 -m10 https://127.0.0.1:8783 | grep ""100000 2xx"""
+  exec "h2load -n100000 -c100 -m10 https://127.0.0.1:8783 | grep \"100000 2xx\""
 
 task h2load2, "h2load test":
   exec "h2load -n100000 -c10 -m1000 -t2 https://127.0.0.1:8783"

--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -29,7 +29,6 @@ export
   sendHeaders,
   sendBody,
   sendEnded,
-  sendRst,
   cancel,
   ClientStream,
   ClientContext,

--- a/src/hyperx/frame.nim
+++ b/src/hyperx/frame.nim
@@ -273,6 +273,13 @@ func newPingFrame*(
     for i in 0 .. frmPingSize-1:
       result.s[frmHeaderSize+i] = ackPayload[i]
 
+func newPingFrame*(data: uint32): Frame {.raises: [].} =
+  result = newFrame(frmPingSize)
+  result.setTyp frmtPing
+  result.setSid frmSidMain
+  result.setPayloadLen frmPingSize.FrmPayloadLen
+  result.s.assignAt(frmHeaderSize, data)
+
 func addSetting*(
   frm: Frame,
   id: FrmSetting,
@@ -344,6 +351,14 @@ func windowSizeInc*(frm: Frame): uint {.inline, raises: [].} =
 
 func errorCode*(frm: Frame): uint32 {.inline, raises: [].} =
   doAssert frm.typ == frmtRstStream
+  result += frm.s[frmHeaderSize+0].uint32 shl 24
+  result += frm.s[frmHeaderSize+1].uint32 shl 16
+  result += frm.s[frmHeaderSize+2].uint32 shl 8
+  result += frm.s[frmHeaderSize+3].uint32
+
+func pingData*(frm: Frame): uint32 {.inline, raises: [].} =
+  # note we ignore the last 4 bytes
+  doAssert frm.typ == frmtPing
   result += frm.s[frmHeaderSize+0].uint32 shl 24
   result += frm.s[frmHeaderSize+1].uint32 shl 16
   result += frm.s[frmHeaderSize+2].uint32 shl 8

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -29,7 +29,6 @@ export
   sendHeaders,
   sendBody,
   sendEnded,
-  sendRst,
   cancel,
   ClientStream,
   newClientStream,

--- a/src/hyperx/signal.nim
+++ b/src/hyperx/signal.nim
@@ -98,9 +98,13 @@ when isMainModule:
       var fut1 = waitLoop(1)
       var fut2 = waitLoop(2)
       sig.trigger()
-      for _ in 0 .. 10:
+      while puts.len != 2:
+        await sleepAsync(1)
+      while sig.waiters.len != 2:
         await sleepAsync(1)
       sig.close()
+      while sig.waiters.len != 0:
+        await sleepAsync(1)
       try:
         await (fut1 and fut2)
       except SignalClosedError:
@@ -121,12 +125,18 @@ when isMainModule:
       var fut1 = waitLoop(1)
       var fut2 = waitLoop(2)
       sig.trigger()
-      for _ in 0 .. 10:
+      while puts.len != 2:
+        await sleepAsync(1)
+      while sig.waiters.len != 2:
         await sleepAsync(1)
       sig.trigger()
-      for _ in 0 .. 10:
+      while puts.len != 4:
+        await sleepAsync(1)
+      while sig.waiters.len != 2:
         await sleepAsync(1)
       sig.close()
+      while sig.waiters.len != 0:
+        await sleepAsync(1)
       try:
         await (fut1 and fut2)
       except SignalClosedError:

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -61,6 +61,14 @@ const strmStateDataSendAllowed* = {
   strmHalfClosedRemote
 }
 
+const strmStateRstSendAllowed* = {
+  strmOpen,
+  strmReservedLocal,
+  strmHalfClosedRemote,
+  strmHalfClosedLocal,
+  strmReservedRemote
+}
+
 func toStreamEvent*(frm: Frame): StreamEvent {.raises: [].} =
   case frm.typ
   of frmtData:
@@ -149,8 +157,7 @@ func toNextStateSend*(s: StreamState, e: StreamEvent): StreamState {.raises: [].
     else: strmOpen
   of strmClosed:
     case e
-    of sePriority,
-      seRstStream: strmClosed
+    of sePriority: strmClosed
     else: strmInvalid
   of strmReservedLocal:
     case e
@@ -374,5 +381,9 @@ when isMainModule:
       for state in allStates - {strmInvalid}:
         let isValid = toNextStateSend(state, ev) != strmInvalid
         doAssert state in strmStateDataSendAllowed == isValid, $state & " " & $ev
+  block:
+    for state in allStates - {strmInvalid}:
+      let isValid = toNextStateSend(state, seRstStream) != strmInvalid
+      doAssert state in strmStateRstSendAllowed == isValid, $state
 
   echo "ok"

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -203,6 +203,7 @@ type
     peerWindowUpdateSig*: SignalAsync
     windowPending*: int
     windowProcessed*: int
+    pingSig*: SignalAsync
     error*: ref StrmError
 
 proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
@@ -214,13 +215,15 @@ proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
     peerWindow: peerWindow,
     peerWindowUpdateSig: newSignal(),
     windowPending: 0,
-    windowProcessed: 0
+    windowProcessed: 0,
+    pingSig: newSignal()
   )
 
 proc close*(stream: Stream) {.raises: [].} =
   stream.state = strmClosed
   stream.msgs.close()
   stream.peerWindowUpdateSig.close()
+  stream.pingSig.close()
 
 type
   StreamsClosedError* = object of HyperxError

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -69,6 +69,13 @@ const strmStateRstSendAllowed* = {
   strmReservedRemote
 }
 
+const strmStateWindowSendAllowed* = {
+  strmOpen,
+  strmHalfClosedRemote,
+  strmHalfClosedLocal,
+  strmReservedRemote
+}
+
 func toStreamEvent*(frm: Frame): StreamEvent {.raises: [].} =
   case frm.typ
   of frmtData:
@@ -385,5 +392,9 @@ when isMainModule:
     for state in allStates - {strmInvalid}:
       let isValid = toNextStateSend(state, seRstStream) != strmInvalid
       doAssert state in strmStateRstSendAllowed == isValid, $state
+  block:
+    for state in allStates - {strmInvalid}:
+      let isValid = toNextStateSend(state, seWindowUpdate) != strmInvalid
+      doAssert state in strmStateWindowSendAllowed == isValid, $state
 
   echo "ok"

--- a/tests/functional/tutils.nim
+++ b/tests/functional/tutils.nim
@@ -5,7 +5,7 @@ import std/parseutils
 import std/asyncdispatch
 
 const localHost* = "127.0.0.1"
-const localPort* = Port 8443
+const localPort* = Port 8763
 const testDataBaseDir = "tests/functional/"
 
 type Header* = (string, string)

--- a/tests/testclientserver.nim
+++ b/tests/testclientserver.nim
@@ -23,7 +23,7 @@ func newStringRef(s = ""): ref string =
   new result
   result[] = s
 
-const localPort = Port 4443
+const localPort = Port 8773
 const localHost = "127.0.0.1"
 const certFile = getEnv "HYPERX_TEST_CERTFILE"
 const keyFile = getEnv "HYPERX_TEST_KEYFILE"


### PR DESCRIPTION
Deal with valid recv'd frames after sending an RST.

~~Not sure how far we can get by only allowing priority frames after closing. Let's see.~~ Allowing window updates is really needed after closing normally (no rst) because of closed state race conditions.

~~Need to send a setting frame and wait for an ACK to make sure the peer got the RST and we can close the stream.~~ Done, but send ping instead of settings.