### PR TITLE
Stream cancel fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src/hyperx/clientserver
 src/hyperx/queue
 src/hyperx/lock
 src/hyperx/signal
+src/hyperx/value
 src/hyperx/untestable
 src/hyperx/frame
 src/hyperx/stream

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/functional/tserver
 tests/functional/tconcurrent
 tests/functional/tconcurrentdata
 tests/functional/tflowcontrol
+tests/functional/tcancel
 src/hyperx/client
 src/hyperx/server
 src/hyperx/clientserver

--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -14,6 +14,7 @@ task test, "Test":
   exec "nim c -r src/hyperx/utils.nim"
   exec "nim c -r src/hyperx/queue.nim"
   exec "nim c -r src/hyperx/signal.nim"
+  exec "nim c -r src/hyperx/value.nim"
   exec "nim c -r src/hyperx/stream.nim"
   exec "nim c -r src/hyperx/frame.nim"
   exec "nim c -r -f -d:hyperxTest -d:ssl src/hyperx/testutils.nim"

--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -60,6 +60,7 @@ task functest, "Func test":
   exec "nim c -r -d:release tests/functional/tconcurrent.nim"
   exec "nim c -r -d:release tests/functional/tconcurrentdata.nim"
   exec "nim c -r -d:release tests/functional/tflowcontrol.nim"
+  exec "nim c -r -d:release tests/functional/tcancel.nim"
 
 task h2spec, "h2spec test":
   exec "./h2spec --tls --port 8783 --strict"

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1225,6 +1225,8 @@ proc cancel*(strm: ClientStream, code: ErrorCode) {.async.} =
     await failSilently strm.writeRst(code)
     await failSilently strm.ping()
   finally:
+    if strm.stream.error == nil:
+      strm.stream.error = newStrmError(errStreamClosed)
     strm.close()
 
 when defined(hyperxTest):

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -897,7 +897,7 @@ proc read(stream: Stream): Future[Frame] {.async.} =
   while true:
     #frm = await stream.msgs.pop()
     frm = await stream.msgs.get()
-    stream.msgs.getDone()
+    #stream.msgs.getDone()
     doAssert stream.id == frm.sid.StreamId
     doAssert frm.typ in frmStreamAllowed
     # this can raise stream/conn error

--- a/src/hyperx/signal.nim
+++ b/src/hyperx/signal.nim
@@ -24,12 +24,11 @@ proc newSignal*(): SignalAsync {.raises: [].} =
     isClosed: false
   )
 
-proc waitFor*(sig: SignalAsync) {.async.} =
+proc waitFor*(sig: SignalAsync): Future[void] {.raises: [SignalClosedError].} =
   if sig.isClosed:
     raise newSignalClosedError()
-  let fut = newFuture[void]()
-  sig.waiters.addFirst fut
-  await fut
+  result = newFuture[void]()
+  sig.waiters.addFirst result
 
 proc wakeupSoon(f: Future[void]) =
   proc wakeup =

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -160,7 +160,7 @@ func toNextStateSend*(s: StreamState, e: StreamEvent): StreamState {.raises: [].
     case e
     of seHeadersEndStream,
       seDataEndStream: strmHalfClosedLocal
-    of seRstStream: strmClosed
+    of seRstStream: strmHalfClosedLocal  # strmClosed
     else: strmOpen
   of strmClosed:
     case e
@@ -180,7 +180,7 @@ func toNextStateSend*(s: StreamState, e: StreamEvent): StreamState {.raises: [].
     else: strmHalfClosedRemote
   of strmHalfClosedLocal, strmReservedRemote:
     case e
-    of seRstStream: strmClosed
+    of seRstStream: s  # strmClosed
     of seWindowUpdate, sePriority: s
     else: strmInvalid
   of strmInvalid:

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -2,6 +2,7 @@ import std/tables
 
 import ./frame
 import ./queue
+import ./value
 import ./signal
 import ./errors
 
@@ -198,7 +199,8 @@ type
   Stream* = ref object
     id*: StreamId
     state*: StreamState
-    msgs*: QueueAsync[Frame]
+    #msgs*: QueueAsync[Frame]
+    msgs*: ValueAsync[Frame]
     peerWindow*: int32
     peerWindowUpdateSig*: SignalAsync
     windowPending*: int
@@ -211,7 +213,8 @@ proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
   Stream(
     id: id,
     state: strmIdle,
-    msgs: newQueue[Frame](1),
+    #msgs: newQueue[Frame](1),
+    msgs: newValueAsync[Frame](),
     peerWindow: peerWindow,
     peerWindowUpdateSig: newSignal(),
     windowPending: 0,
@@ -259,7 +262,7 @@ func open*(
 ): Stream {.raises: [StreamsClosedError].} =
   doAssert sid notin s.t, $sid.int
   if s.isClosed:
-    raise newException(StreamsClosedError, "Streams is closed")
+    raise newException(StreamsClosedError, "Cannot open stream")
   result = newStream(sid, peerWindow)
   s.t[sid] = result
 

--- a/src/hyperx/value.nim
+++ b/src/hyperx/value.nim
@@ -42,16 +42,18 @@ proc get*[T](vala: ValueAsync[T]): Future[T] {.async.} =
   try:
     while vala.val == nil:
       await vala.sigGet.waitFor()
-  except SignalClosedError:
-    raise newValueAsyncClosedError()
-  result = vala.val
-
-proc getDone*[T](vala: ValueAsync[T]) =
-  vala.val = nil
-  try:
+    result = vala.val
+    vala.val = nil
     vala.sigPut.trigger()
   except SignalClosedError:
     raise newValueAsyncClosedError()
+
+#proc getDone*[T](vala: ValueAsync[T]) =
+#  vala.val = nil
+#  try:
+#    vala.sigPut.trigger()
+#  except SignalClosedError:
+#    raise newValueAsyncClosedError()
 
 proc close*[T](vala: ValueAsync[T]) {.raises: [].} =
   if vala.isClosed:

--- a/src/hyperx/value.nim
+++ b/src/hyperx/value.nim
@@ -1,0 +1,83 @@
+import std/asyncdispatch
+
+import ./signal
+import ./errors
+
+type
+  ValueAsyncClosedError* = QueueClosedError
+
+func newValueAsyncClosedError(): ref ValueAsyncClosedError {.raises: [].} =
+  result = (ref ValueAsyncClosedError)(msg: "ValueAsync is closed")
+
+type
+  ValueAsync*[T] = ref object
+    sigPut, sigGet: SignalAsync
+    val: T
+    isClosed: bool
+
+func newValueAsync*[T](): ValueAsync[T] {.raises: [].} =
+  ValueAsync[T](
+    sigPut: newSignal(),
+    sigGet: newSignal(),
+    val: nil,
+    isClosed: false
+  )
+
+proc put*[T](vala: ValueAsync[T], val: T) {.async.} =
+  if vala.isClosed:
+    raise newValueAsyncClosedError()
+  try:
+    while vala.val != nil:
+      await vala.sigPut.waitFor()
+    vala.val = val
+    vala.sigGet.trigger()
+    while vala.val != nil:
+      await vala.sigPut.waitFor()
+  except SignalClosedError:
+    raise newValueAsyncClosedError()
+
+proc get*[T](vala: ValueAsync[T]): Future[T] {.async.} =
+  if vala.isClosed:
+    raise newValueAsyncClosedError()
+  try:
+    while vala.val == nil:
+      await vala.sigGet.waitFor()
+  except SignalClosedError:
+    raise newValueAsyncClosedError()
+  result = vala.val
+
+proc getDone*[T](vala: ValueAsync[T]) =
+  vala.val = nil
+  try:
+    vala.sigPut.trigger()
+  except SignalClosedError:
+    raise newValueAsyncClosedError()
+
+proc close*[T](vala: ValueAsync[T]) {.raises: [].} =
+  if vala.isClosed:
+    return
+  vala.isClosed = true
+  vala.sigPut.close()
+  vala.sigGet.close()
+
+when isMainModule:
+  func newIntRef(n: int): ref int =
+    new result
+    result[] = n
+  block:
+    proc test() {.async.} =
+      var q = newValueAsync[ref int]()
+      proc puts {.async.} =
+        await q.put newIntRef(1)
+        await q.put newIntRef(2)
+        await q.put newIntRef(3)
+        await q.put newIntRef(4)
+      let puts1 = puts()
+      doAssert (await q.get())[] == 1
+      doAssert (await q.get())[] == 2
+      doAssert (await q.get())[] == 3
+      doAssert (await q.get())[] == 4
+      await puts1
+    waitFor test()
+    doAssert not hasPendingOperations()
+  echo "ok"

--- a/tests/functional/tcancel.nim
+++ b/tests/functional/tcancel.nim
@@ -1,0 +1,112 @@
+{.define: ssl.}
+{.define: hyperxSanityCheck.}
+
+import std/asyncdispatch
+import ../../src/hyperx/client
+import ../../src/hyperx/signal
+import ../../src/hyperx/errors
+import ./tutils.nim
+from ../../src/hyperx/clientserver import stgWindowSize
+
+const strmsPerClient = 1123
+const clientsCount = 25
+const strmsInFlight = 100
+const dataPayloadLen = stgWindowSize.int * 2 + 123
+
+proc send(strm: ClientStream) {.async.} =
+  await strm.sendHeaders(
+    newSeqRef(@[
+      (":method", "POST"),
+      (":scheme", "https"),
+      (":path", "/file/"),
+      (":authority", "foo.bar"),
+      ("user-agent", "HyperX/0.1"),
+      ("content-type", "text/plain")
+    ]),
+    finish = false
+  )
+  var sentBytes = 0
+  var data = newStringRef newString(16 * 1024 + 123)
+  while sentBytes < dataPayloadLen:
+    await strm.sendBody(data, finish = false)
+    sentBytes += data[].len
+  await strm.sendBody(data, finish = true)
+
+proc recv(strm: ClientStream) {.async.} =
+  var data = newStringref()
+  await strm.recvHeaders(data)
+  doAssert data[] == ":status: 200\r\n"
+  data[].setLen 0
+  while not strm.recvEnded:
+    await strm.recvBody(data)
+    await strm.cancel(errCancel)  # CANCEL
+
+proc spawnStream(
+  client: ClientContext,
+  checked: ref int
+) {.async.} =
+  let strm = client.newClientStream()
+  with strm:
+    let recvFut = strm.recv()
+    let sendFut = strm.send()
+    try:
+      await recvFut
+    except StrmError as err:
+      doAssert err.typ == hxLocalErr
+      doAssert err.code == errStreamClosed
+    try:
+      await sendFut
+    except StrmError as err:
+      doAssert err.typ == hxLocalErr
+      doAssert err.code == errStreamClosed
+    inc checked[]
+    return
+
+proc spawnStream(
+  client: ClientContext,
+  checked: ref int,
+  sig: SignalAsync,
+  inFlight: ref int
+) {.async.} =
+  try:
+    await spawnStream(client, checked)
+  finally:
+    inFlight[] -= 1
+    sig.trigger()
+
+proc spawnClient(
+  checked: ref int
+) {.async.} =
+  var client = newClient(localHost, localPort)
+  with client:
+    var stmsCount = 0
+    var inFlight = new(int)
+    inFlight[] = 0
+    var sig = newSignal()
+    while stmsCount < strmsPerClient:
+      inFlight[] = inFlight[] + 1
+      asyncCheck spawnStream(client, checked, sig, inFlight)
+      inc stmsCount
+      if stmsCount >= strmsPerClient:
+        break
+      if inFlight[] == strmsInFlight:
+        await sig.waitFor()
+    while inFlight[] > 0:
+      await sig.waitFor()
+
+proc main() {.async.} =
+  let checked = new(int)
+  checked[] = 0
+  var clients = newSeq[Future[void]]()
+  for _ in 0 .. clientsCount-1:
+    clients.add spawnClient(checked)
+  for clientFut in clients:
+    await clientFut
+  doAssert checked[] == clientsCount * strmsPerClient
+  echo "checked ", $checked[]
+
+(proc =
+  waitFor main()
+  doAssert not hasPendingOperations()
+  echo "ok"
+)()

--- a/tests/functional/tcancel.nim
+++ b/tests/functional/tcancel.nim
@@ -9,7 +9,7 @@ import ./tutils.nim
 from ../../src/hyperx/clientserver import stgWindowSize
 
 const strmsPerClient = 1123
-const clientsCount = 25
+const clientsCount = 13
 const strmsInFlight = 100
 const dataFrameLen = 1
 #const dataFrameLen = stgWindowSize.int * 2 + 123
@@ -26,7 +26,7 @@ proc send(strm: ClientStream) {.async.} =
     ]),
     finish = false
   )
-  var data = newStringRef newString(dataFrameLen)
+  let data = newStringRef newString(dataFrameLen)
   while true:
     await strm.sendBody(data, finish = false)
 
@@ -45,8 +45,8 @@ proc spawnStream(
 ) {.async.} =
   let strm = client.newClientStream()
   with strm:
-    let recvFut = strm.recv()
     let sendFut = strm.send()
+    let recvFut = strm.recv()
     try:
       await recvFut
     except StrmError as err:

--- a/tests/functional/tconcurrentdata.nim
+++ b/tests/functional/tconcurrentdata.nim
@@ -98,6 +98,8 @@ proc spawnClient(
     var sig = newSignal()
     while stmsCount < strmsPerClient:
       for req in reqsCtx.s:
+        if not client.isConnected:
+          return
         inFlight[] = inFlight[] + 1
         asyncCheck spawnStream(client, req, checked, sig, inFlight)
         inc stmsCount

--- a/tests/functional/tflowcontrol.nim
+++ b/tests/functional/tflowcontrol.nim
@@ -98,6 +98,8 @@ proc spawnClient(
     var sig = newSignal()
     while stmsCount < strmsPerClient:
       for req in reqsCtx.s:
+        if not client.isConnected:
+          return
         inFlight[] = inFlight[] + 1
         asyncCheck spawnStream(client, req, checked, sig, inFlight)
         inc stmsCount

--- a/tests/functional/tflowcontrol.nim
+++ b/tests/functional/tflowcontrol.nim
@@ -43,7 +43,6 @@ func newReqsCtx(): ReqsCtx =
   )
 
 proc send(strm: ClientStream, req: Req) {.async.} =
-  # XXX send multiple data frames
   await strm.sendHeaders(req.headers.s, finish = false)
   await strm.sendBody(req.data.s, finish = true)
 

--- a/tests/functional/tserver.nim
+++ b/tests/functional/tserver.nim
@@ -50,6 +50,7 @@ proc processClientHandler(client: ClientContext) {.async.} =
     debugEcho err.msg
   when defined(hyperxStats):
     echoStats client
+  #GC_fullCollect()
 
 proc serve(server: ServerContext) {.async.} =
   with server:


### PR DESCRIPTION
Follow up PR #21

Added the ClosedRst (almost-closed) stream state described here: https://nitely.github.io/2024/08/20/http-2-the-missing-state.html

Note that the reserved-local/remote states are wrong, but it does not matter since push-promise is not supported anyway.