### PR TITLE
Fix count data padding as flow control

### DIFF
--- a/src/hyperx/frame.nim
+++ b/src/hyperx/frame.nim
@@ -153,6 +153,8 @@ func shrink*(frm: Frame, size: int) {.inline, raises: [].} =
   frm.s.setLen frm.s.len-size
 
 func payloadLen*(frm: Frame): FrmPayloadLen {.inline, raises: [].} =
+  ## This can include padding and prio len,
+  ## and be greater than frm.payload.len
   # XXX: validate this is equal to frm.s.len-frmHeaderSize on read
   result += frm.s[0].uint32 shl 16
   result += frm.s[1].uint32 shl 8


### PR DESCRIPTION
> The entire DATA frame payload is included in flow control, including the Pad Length and Padding fields if present. https://www.rfc-editor.org/rfc/rfc9113.html#section-6.1

^ this, and a small read refactor