### PR TITLE
Raise on recv canceled

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1059,7 +1059,7 @@ proc recvHeaders*(strm: ClientStream, data: ref string) {.async.} =
 proc recvBodyNaked(strm: ClientStream, data: ref string) {.async.} =
   template client: untyped = strm.client
   template stream: untyped = strm.stream
-  if strm.stateRecv != csStateEnded and strm.bodyRecv.len == 0:
+  if strm.bodyRecv.len == 0:
     await strm.bodyRecvSig.waitFor()
   let bodyL = strm.bodyRecvLen
   data[].add strm.bodyRecv

--- a/tests/functional/tcancelremote.nim
+++ b/tests/functional/tcancelremote.nim
@@ -29,7 +29,7 @@ proc send(strm: ClientStream) {.async.} =
     finish = false
   )
   let data = newStringRef newString(dataFrameLen)
-  while true:
+  while true:  # until server cancel
     await strm.sendBody(data, finish = false)
 
 proc recv(strm: ClientStream) {.async.} =
@@ -37,7 +37,7 @@ proc recv(strm: ClientStream) {.async.} =
   await strm.recvHeaders(data)
   doAssert data[] == ":status: 200\r\n"
   data[].setLen 0
-  while not strm.recvEnded:
+  while true:  # until server cancel
     await strm.recvBody(data)
     doAssert data[].len == 0
 


### PR DESCRIPTION
recvBody returns empty when the stream is canceled in between checking stream.recvEnded and await recvBody. If there is some other await before recvBody.

This makes things consistent, and user can do `while true` until the stream is canceled or it ends.

But if streams ends with trailers or empty data, this will raise a closed queue error, mmmh