### PR TITLE
Lazy client stream id

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -184,16 +184,6 @@ func openMainStream(client: ClientContext): Stream {.raises: [StreamsClosedError
   doAssert frmSidMain notin client.streams
   result = client.streams.open(frmSidMain, client.peerWindowSize.int32)
 
-func openStream(client: ClientContext): Stream {.raises: [StreamsClosedError, GracefulShutdownError].} =
-  # XXX some error if max sid is reached
-  # XXX error if maxStreams is reached
-  doAssert client.typ == ctClient
-  check not client.isGracefulShutdown, newGracefulShutdownError()
-  var sid = client.currStreamId
-  sid += (if sid == StreamId 0: StreamId 1 else: StreamId 2)
-  result = client.streams.open(sid, client.peerWindowSize.int32)
-  client.currStreamId = sid
-
 func maxPeerStreamIdSeen(client: ClientContext): StreamId {.raises: [].} =
   case client.typ
   of ctClient: StreamId 0

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -794,6 +794,8 @@ func newClientStream*(client: ClientContext, stream: Stream): ClientStream =
   )
 
 func newClientStream*(client: ClientContext): ClientStream =
+  doAssert client.typ == ctClient
+  check not client.isGracefulShutdown, newGracefulShutdownError()
   let stream = client.streams.dummy()
   newClientStream(client, stream)
 

--- a/src/hyperx/frame.nim
+++ b/src/hyperx/frame.nim
@@ -114,6 +114,7 @@ type
 proc `==`*(a, b: FrmSid): bool {.borrow.}
 proc `+=`*(a: var FrmSid, b: FrmSid) {.borrow.}
 proc `<`*(a, b: FrmSid): bool {.borrow.}
+proc `<=`*(a, b: FrmSid): bool {.borrow.}
 
 #func `+=`*(a: var FrmSid, b: uint) {.raises: [].} =
 #  a = (a.uint + b).FrmSid

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -174,17 +174,6 @@ type
     pingSig*: SignalAsync
     error*: ref HyperxStrmError
 
-proc newStream*: Stream {.raises: [].} =
-  Stream(
-    id: uint32.high.StreamId,
-    state: strmIdle,
-    msgs: newValueAsync[Frame](),
-    peerWindowUpdateSig: newSignal(),
-    windowPending: 0,
-    windowProcessed: 0,
-    pingSig: newSignal()
-  )
-
 proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
   doAssert peerWindow >= 0
   Stream(
@@ -261,7 +250,7 @@ func open*(
 
 func dummy*(s: var Streams): Stream {.raises: [StreamsClosedError].} =
   check not s.isClosed, newStreamsClosedError("Cannot open stream")
-  result = newStream()
+  result = newStream(uint32.high.StreamId, 0)
 
 iterator values*(s: Streams): Stream {.inline.} =
   for v in values s.t:

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -225,15 +225,9 @@ func del*(s: var Streams, sid: StreamId) {.raises: [].} =
 func contains*(s: Streams, sid: StreamId): bool {.raises: [].} =
   s.t.contains sid
 
-func open*(
-  s: var Streams,
-  sid: StreamId,
-  peerWindow: int32
-): Stream {.raises: [StreamsClosedError].} =
-  doAssert sid notin s.t, $sid.int
+func dummy*(s: var Streams): Stream {.raises: [StreamsClosedError].} =
   check not s.isClosed, newStreamsClosedError("Cannot open stream")
-  result = newStream(sid, peerWindow)
-  s.t[sid] = result
+  result = newStream(uint32.high.StreamId, 0)
 
 func open*(
   s: var Streams,
@@ -241,6 +235,7 @@ func open*(
   sid: StreamId,
   peerWindow: int32
 ) {.raises: [StreamsClosedError].} =
+  doAssert sid notin s.t, $sid.int
   doAssert stream.id == uint32.high.StreamId
   doAssert stream.state == strmIdle
   check not s.isClosed, newStreamsClosedError("Cannot open stream")
@@ -248,9 +243,13 @@ func open*(
   stream.peerWindow = peerWindow
   s.t[sid] = stream
 
-func dummy*(s: var Streams): Stream {.raises: [StreamsClosedError].} =
-  check not s.isClosed, newStreamsClosedError("Cannot open stream")
-  result = newStream(uint32.high.StreamId, 0)
+func open*(
+  s: var Streams,
+  sid: StreamId,
+  peerWindow: int32
+): Stream {.raises: [StreamsClosedError].} =
+  result = s.dummy()
+  s.open(result, sid, peerWindow)
 
 iterator values*(s: Streams): Stream {.inline.} =
   for v in values s.t:

--- a/tests/functional/tmisc.nim
+++ b/tests/functional/tmisc.nim
@@ -218,3 +218,19 @@ testAsync "lazy client stream id":
     doAssert order[] == @[100, 200]
     checked[] += 1
   doAssert checked[] == 5
+
+testAsync "cancel lazy stream":
+  var checked = 0
+  var client = newClient(localHost, localPort)
+  with client:
+    let strm = client.newClientStream()
+    await strm.cancel(hyxCancel)
+    with strm:
+      try:
+        await strm.sendHeaders(defaultHeaders, finish = true)
+        doAssert false
+      except HyperxStrmError as err:
+        doAssert err.code == hyxStreamClosed
+      inc checked
+    inc checked
+  doAssert checked == 2

--- a/tests/testclient.nim
+++ b/tests/testclient.nim
@@ -428,10 +428,10 @@ testAsync "stream error NO_ERROR handling":
     await tc.checkHandshake()
     let strm = tc.client.newClientStream()
     with strm:
-      await tc.replyNoError(strm.stream.id)
       let sendFut = strm.send(dataOut)
       let recvFut = strm.recv(dataIn)
-      await sendFut  # this could raise
+      await sendFut
+      await tc.replyNoError(strm.stream.id)
       await recvFut  # this should never raise
   doAssert dataIn[] == headers
 


### PR DESCRIPTION
Currently `await sendHeaders()` must be the top await within a `with(stream)` block. This makes it so awaits before sendHeaders are ok.

```nim
let strm = newStream()
with strm:
  await sleepAsync(1)
  await strm.sendHeaders(...)
```