### PR TITLE
Make stream callback safe for the multi-thread server

### DIFF
--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -166,6 +166,8 @@ proc sendHeaders*(
 
 type StreamCallback* =
   proc (stream: ClientStream): Future[void] {.closure, gcsafe.}
+type SafeStreamCallback* =
+  proc (stream: ClientStream): Future[void] {.nimcall, gcsafe.}
 
 proc processStreamHandler(
   strm: ClientStream,
@@ -236,7 +238,7 @@ proc worker(ctx: ptr WorkerContext) {.thread.} =
 proc run*(
   hostname: string,
   port: Port,
-  callback: StreamCallback,
+  callback: SafeStreamCallback,
   sslCertFile = "",
   sslKeyFile = "",
   maxConnections = defaultMaxConns,


### PR DESCRIPTION
in theory passing a ptr object storing GC data types to threads should be ok, but better make the callback a nimcall to be safe.