### PR TITLE
Improve frame creation

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -856,7 +856,7 @@ proc read(stream: Stream): Future[Frame] {.async.} =
   var frm: Frame
   while true:
     frm = await stream.msgs.get()
-    #stream.msgs.getDone()
+    stream.msgs.getDone()
     doAssert stream.id == frm.sid
     doAssert frm.typ in frmStreamAllowed
     # this can raise stream/conn error

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -384,7 +384,7 @@ proc handshake(client: ClientContext) {.async.} =
 
 func doTransitionRecv(
   s: Stream, frm: Frame
-) {.raises: [HyperxConnError, HyperxStrmError].} =
+) {.raises: [HyperxConnError].} =
   doAssert frm.sid == s.id
   doAssert frm.sid != frmSidMain
   doAssert s.state != strmInvalid

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -653,6 +653,11 @@ proc recvDispatcher(client: ClientContext) {.async.} =
   except HyperxStrmError:
     debugErr getCurrentException()
     doAssert false
+  except OsError, SslError:
+    let err = getCurrentException()
+    debugErr2 err
+    client.error ?= newConnError(err.msg)
+    raise newConnError(err.msg, err)
   except CatchableError as err:
     debugErr2 err
     raise err

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -392,7 +392,10 @@ func doTransitionRecv(
   let nextState = toNextStateRecv(s.state, frm.toStreamEvent)
   if nextState == strmInvalid:
     if s.state == strmHalfClosedRemote:
-      raise newStrmError(hyxStreamClosed)
+      # This used to be a strmError, but it was raicy.
+      # Since we may send an END_STREAM before
+      # this propagates, and we cannot send the RST on a closed stream.
+      raise newConnError(hyxStreamClosed)
     if s.state == strmClosed:
       raise newConnError(hyxStreamClosed)
     raise newConnError(hyxProtocolError)

--- a/src/hyperx/value.nim
+++ b/src/hyperx/value.nim
@@ -49,6 +49,8 @@ proc get*[T](vala: ValueAsync[T]): Future[T] {.async.} =
   doAssert vala.val != nil
   result = vala.val
   vala.val = nil
+
+proc getDone*[T](vala: ValueAsync[T]) {.raises: [].} =
   wakeupSoon vala.putWaiter
 
 proc failSoon(f: Future[void]) {.raises: [].} =
@@ -83,9 +85,13 @@ when isMainModule:
         doAssert q.val == nil
       let puts1 = puts()
       doAssert (await q.get())[] == 1
+      q.getDone()
       doAssert (await q.get())[] == 2
+      q.getDone()
       doAssert (await q.get())[] == 3
+      q.getDone()
       doAssert (await q.get())[] == 4
+      q.getDone()
       await puts1
     waitFor test()
     doAssert not hasPendingOperations()
@@ -94,9 +100,13 @@ when isMainModule:
       var q = newValueAsync[ref int]()
       proc gets {.async.} =
         doAssert (await q.get())[] == 1
+        q.getDone()
         doAssert (await q.get())[] == 2
+        q.getDone()
         doAssert (await q.get())[] == 3
+        q.getDone()
         doAssert (await q.get())[] == 4
+        q.getDone()
       let gets1 = gets()
       await q.put newIntRef(1)
       doAssert q.val == nil
@@ -114,6 +124,7 @@ when isMainModule:
       var q = newValueAsync[ref int]()
       proc gets {.async.} =
         doAssert (await q.get())[] == 1
+        q.getDone()
         q.close()
       let gets1 = gets()
       await q.put newIntRef(1)


### PR DESCRIPTION
this shows no improvement btw, maybe on yasync it does

This revealed a race condition in the stream recv transition. Raises cause race conditions as they are Future.fail() calls that set callbacks to continue later. In the meantime an END_STREAM may have been sent. So the RST won't be sent.

But I think this does not matter. The only time RST won't be sent is if the stream got closed, which gives the same result: the stream is closed. However, this makes the h2spec fail.

It's really hard to fix properly:

- We could set the stream state to RstClosing (yes, a new stream state) before raising. The except handler would send a cancel() that makes sure the client received the RST, before calling stream.close(), so we can keep receiving frames in between. The END_STREAM the user is trying to send will raise an error (because RstClosing state), propagate, and send the Rst; this creates a race of which Rst is sent first; and sending an Rst STREAM_CLOSED does not make sense if the strmError was causes by a different error code. So this does not work well in general, but for `newStrmError(hyxStreamClosed)` this happens to work, because trying to send headers/data on RstClosed state results in the same error code.
- Even if we do this, there is a race condition. If we send the END_STREAM, close the stream, and receive more data/headers frames in that stream, a conn error is raised. The only way to prevent this, would be sending a PING after every END_STREAM to make sure the peer received the END_STREAM; which keeps streams alive for too long, requires an extra round trip, etc, so no.

Given all stream errors can be replaced by conn errors (the spec allows this), it seems better to just raise a conn error here.