### PR TITLE
buffered send

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -346,7 +346,7 @@ proc send(client: ClientContext, frm: Frame) {.async.} =
     await client.sendBuffDoneSig.waitFor()
   elif frm.typ in {frmtHeaders, frmtData} and frmfEndStream in frm.flags:
     await client.sendBuffDoneSig.waitFor()
-  elif client.sendBuff.len > max(stgWindowSize, 64 * 1024):
+  elif client.sendBuff.len > 8 * 1024:
     await client.sendBuffDoneSig.waitFor()
 
 proc sendSilently(client: ClientContext, frm: Frame) {.async.} =

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -331,6 +331,8 @@ proc send(client: ClientContext, frm: Frame) {.async.} =
     client.sendBuf.len > 16 * 1024
   if waitDrain:
     await client.sendBufDrainSig.waitFor()
+  #if frm.typ == frmtGoAway:
+  #  await client.sendBufDoneSig.waitFor()
   when defined(hyperxStats):
     client.frmsSent += 1
     client.frmsSentTyp[frm.typ.int] += 1

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -342,12 +342,13 @@ proc send(client: ClientContext, frm: Frame) {.async.} =
   client.sendBuffSig.trigger()
   # XXX this is right if not currently sending a buff, need to wait again
   #     if currently sending.
-  if frm.typ in {frmtRstStream, frmtGoAway}:
-    await client.sendBuffDoneSig.waitFor()
-  elif frm.typ in {frmtHeaders, frmtData} and frmfEndStream in frm.flags:
-    await client.sendBuffDoneSig.waitFor()
-  elif client.sendBuff.len > 8 * 1024:
-    await client.sendBuffDoneSig.waitFor()
+  #if frm.typ in {frmtRstStream, frmtGoAway}:
+  #  await client.sendBuffDoneSig.waitFor()
+  #elif frm.typ in {frmtHeaders, frmtData} and frmfEndStream in frm.flags:
+  #  await client.sendBuffDoneSig.waitFor()
+  #elif client.sendBuff.len > 8 * 1024:
+  #  await client.sendBuffDoneSig.waitFor()
+  await client.sendBuffDoneSig.waitFor()
 
 proc sendSilently(client: ClientContext, frm: Frame) {.async.} =
   ## Call this to send within an except

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -331,11 +331,11 @@ proc send(client: ClientContext, frm: Frame) {.async.} =
     client.sendBuf.len > 16 * 1024
   if waitDrain:
     await client.sendBufDrainSig.waitFor()
-  # XXX hack
   if frm.typ == frmtGoAway:
-    client.sendBuf.add frm.s
-    check not client.sendBufSig.isClosed, newConnClosedError()
-    client.sendBufSig.trigger()
+    if client.sendBuf == 0:  # XXX hack
+      client.sendBuf.add frm.s
+      check not client.sendBufSig.isClosed, newConnClosedError()
+      client.sendBufSig.trigger()
     await client.sendBufDrainSig.waitFor()
   when defined(hyperxStats):
     client.frmsSent += 1

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -342,13 +342,14 @@ proc send(client: ClientContext, frm: Frame) {.async.} =
   client.sendBuffSig.trigger()
   # XXX this is right if not currently sending a buff, need to wait again
   #     if currently sending.
-  #if frm.typ in {frmtRstStream, frmtGoAway}:
-  #  await client.sendBuffDoneSig.waitFor()
-  #elif frm.typ in {frmtHeaders, frmtData} and frmfEndStream in frm.flags:
-  #  await client.sendBuffDoneSig.waitFor()
-  #elif client.sendBuff.len > 8 * 1024:
-  #  await client.sendBuffDoneSig.waitFor()
-  await client.sendBuffDoneSig.waitFor()
+  if frm.typ in {frmtRstStream, frmtGoAway}:
+    await client.sendBuffDoneSig.waitFor()
+  elif frm.typ == frmtHeaders and frmfEndStream in frm.flags:
+    await client.sendBuffDoneSig.waitFor()
+  elif frm.typ == frmtData:
+    await client.sendBuffDoneSig.waitFor()
+  elif client.sendBuff.len > 16 * 1024:
+    await client.sendBuffDoneSig.waitFor()
 
 proc sendSilently(client: ClientContext, frm: Frame) {.async.} =
   ## Call this to send within an except

--- a/src/hyperx/testutils.nim
+++ b/src/hyperx/testutils.nim
@@ -32,6 +32,12 @@ template testAsync*(name: string, body: untyped): untyped =
       doAssert stats.allocCount == stats.deallocCount
   )()
 
+proc sleepCycle*: Future[void] =
+  let fut = newFuture[void]()
+  proc wakeup = fut.complete()
+  callSoon wakeup
+  return fut
+
 func toString(bytes: openArray[byte]): string =
   result = ""
   for b in bytes:

--- a/tests/functional/tcancel.nim
+++ b/tests/functional/tcancel.nim
@@ -11,7 +11,7 @@ from ../../src/hyperx/clientserver import stgWindowSize
 const strmsPerClient = 1123
 const clientsCount = 13
 const strmsInFlight = 100
-const dataFrameLen = 1
+const dataFrameLen = 1111
 #const dataFrameLen = stgWindowSize.int * 2 + 123
 
 proc send(strm: ClientStream) {.async.} =

--- a/tests/functional/tmisc.nim
+++ b/tests/functional/tmisc.nim
@@ -16,6 +16,7 @@ template testAsync(name: string, body: untyped): untyped =
     proc test {.async.} =
       body
       checked = true
+    discard getGlobalDispatcher()
     waitFor test()
     doAssert not hasPendingOperations()
     doAssert checked

--- a/tests/testclient.nim
+++ b/tests/testclient.nim
@@ -460,7 +460,7 @@ testAsync "stream NO_ERROR before request completes":
         await tc.replyNoError(strm.stream.id)
         # wait for the rst
         while strm.stream.state != strmClosed:
-          await sleepAsync(1)
+          await sleepCycle()
         try:
           await strm.recv(dataIn)  # this should never raise
         except HyperxError:

--- a/tests/testclientserver.nim
+++ b/tests/testclientserver.nim
@@ -12,6 +12,7 @@ template testAsync(name: string, body: untyped): untyped =
     echo "test " & name
     proc test() {.async.} =
       body
+    discard getGlobalDispatcher()
     waitFor test()
     doAssert not hasPendingOperations()
     when false:

--- a/tests/testserver.nim
+++ b/tests/testserver.nim
@@ -109,7 +109,7 @@ testAsync "exceed window size":
       sentCount += text.len
     var i = 0
     while tc.client.isConnected:
-      await sleepAsync(0)
+      await sleepCycle()
       inc i
       doAssert i < 1000
 
@@ -233,7 +233,6 @@ testAsync "exceed settings list":
       for _ in 0 .. stgMaxSettingsList.int+1:
         frmSetting.addSetting(0x09.FrmSetting, 1000.uint32)
       await tc1.recv frmSetting.s
-      await tc1.recv headers
       try:
         discard await client1.recvStream()
         doAssert false


### PR DESCRIPTION
headers only:
```
finished in 3.83s, 261247.56 req/s, 2.49MB/s
```

hello world body:
```
finished in 4.59s, 217842.48 req/s, 6.44MB/s
```

<details>
<summary>CI before:</summary>

```
finished in 3.59s, 27850.40 req/s, 843.24KB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 2.96MB (3100430) total, 97.66KB (100000) headers (space savings 90.00%), 1.14MB (1200000) data
                     min         max         mean         sd        +/- sd
time for request:    15.15ms     52.66ms     35.40ms      4.26ms    73.25%
time for connect:     2.03ms     19.17ms      9.02ms      4.22ms    80.00%
time to 1st byte:    25.52ms     71.61ms     41.46ms     13.94ms    70.00%
req/s           :    2786.25     2807.94     2796.60        6.33    70.00%
```

</details>


<details>
<summary>CI after:</summary>

```
finished in 1.74s, 57332.38 req/s, 1.70MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 2.96MB (3100430) total, 97.66KB (100000) headers (space savings 90.00%), 1.14MB (1200000) data
                     min         max         mean         sd        +/- sd
time for request:     4.09ms     24.52ms     17.12ms      1.04ms    96.68%
time for connect:     3.61ms     31.43ms     13.78ms     10.16ms    80.00%
time to 1st byte:    13.01ms     56.05ms     31.20ms     15.48ms    60.00%
req/s           :    5737.81     5811.33     5769.92       28.46    60.00%
```

</details>

More importantly this buffers tiny frames, keeping throughput high and latency low.