### PR TITLE
Remove value async; follow up #52

### DIFF
--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -87,7 +87,7 @@ task h2load, "h2load test":
   exec "h2load -n100000 -c100 -m10 https://127.0.0.1:8783 | grep \"100000 2xx\""
 
 task h2load2, "h2load test":
-  exec "h2load -n100000 -c10 -m1000 -t2 https://127.0.0.1:8783"
+  exec "h2load -n500000 -c10 -m100 https://127.0.0.1:8783"
 
 task docs, "Docs":
   exec "nim doc2 -o:./docs --project ./src/hyperx.nim"

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -10,7 +10,6 @@ import pkg/hpack
 
 import ./frame
 import ./stream
-import ./value
 import ./signal
 import ./errors
 import ./utils
@@ -124,7 +123,8 @@ type
     isGracefulShutdown: bool
     headersEnc, headersDec: DynHeaders
     streams: Streams
-    streamOpenedMsgs*: ValueAsync[Stream]
+    streamsRecv*: seq[Stream]
+    streamsRecvSig*: SignalAsync
     currStreamId: StreamId
     peerMaxConcurrentStreams: uint32
     peerWindowSize: uint32
@@ -159,7 +159,8 @@ proc newClient*(
     headersDec: initDynHeaders(stgHeaderTableSize.int),
     streams: initStreams(),
     currStreamId: 0.StreamId,
-    streamOpenedMsgs: newValueAsync[Stream](),
+    streamsRecv: newSeq[Stream](),
+    streamsRecvSig: newSignal(),
     peerMaxConcurrentStreams: stgInitialMaxConcurrentStreams,
     peerWindow: stgInitialWindowSize.int32,
     peerWindowSize: stgInitialWindowSize,
@@ -181,7 +182,7 @@ proc close*(client: ClientContext) {.raises: [HyperxConnError].} =
   try:
     catch client.sock.close()
   finally:
-    client.streamOpenedMsgs.close()
+    client.streamsRecvSig.close()
     client.streams.close()
     client.peerWindowUpdateSig.close()
     client.windowUpdateSig.close()
@@ -211,7 +212,7 @@ when defined(hyperxStats):
 when defined(hyperxSanityCheck):
   func sanityCheckAfterClose(client: ClientContext) {.raises: [].} =
     doAssert not client.isConnected
-    doAssert client.streamOpenedMsgs.isClosed
+    doAssert client.streamsRecvSig.isClosed
     doAssert client.peerWindowUpdateSig.isClosed
     doAssert client.windowUpdateSig.isClosed
     doAssert client.windowProcessed >= 0
@@ -710,7 +711,7 @@ proc process(client: ClientContext, stream: Stream, frm: Frame) =
   else:
     doAssert frm.typ in {frmtData, frmtHeaders}
     case stream.stateRecv
-    of csStateOpened, csStateHeaders:
+    of csStateInitial, csStateOpened, csStateHeaders:
       stream.stateRecv = csStateHeaders
       processHeaders(client, stream, frm)
     of csStateData:
@@ -750,7 +751,8 @@ proc recvDispatcherNaked(client: ClientContext, mainStream: Stream) {.async.} =
       client.currStreamId = frm.sid
       # we do not store idle streams, so no need to close them
       let strm = client.streams.open(frm.sid, client.peerWindowSize.int32)
-      await client.streamOpenedMsgs.put strm
+      client.streamsRecv.add strm
+      client.streamsRecvSig.trigger()
     if frm.typ == frmtHeaders:
       headers.setLen 0
       client.hpackDecode(headers, frm.payload)
@@ -1111,9 +1113,9 @@ proc sendBody*(
     raise err
 
 template with*(strm: ClientStream, body: untyped): untyped =
-  doAssert strm.stream.stateRecv == csStateInitial
+  #doAssert strm.stream.stateRecv == csStateInitial
   doAssert strm.stream.stateSend == csStateInitial
-  strm.stream.stateRecv = csStateOpened
+  #strm.stream.stateRecv = csStateOpened
   strm.stream.stateSend = csStateOpened
   try:
     block:

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -162,8 +162,6 @@ func toNextStateSend*(s: StreamState, e: StreamEvent): StreamState {.raises: [].
 
 type
   StreamCtxState* = enum
-    csStateInitial,
-    csStateOpened,
     csStateHeaders,
     csStateData,
     csStateEnded
@@ -193,8 +191,8 @@ proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
     windowPending: 0,
     windowProcessed: 0,
     pingSig: newSignal(),
-    stateRecv: csStateInitial,
-    stateSend: csStateInitial,
+    stateRecv: csStateHeaders,
+    stateSend: csStateHeaders,
     contentLen: 0,
     contentLenRecv: 0,
     bodyRecv: "",


### PR DESCRIPTION
Finally reaching ok performance.

CI before:

```
finished in 1.20s, 83073.11 req/s, 2.46MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 2.96MB (3100430) total, 97.66KB (100000) headers (space savings 90.00%), 1.14MB (1200000) data
                     min         max         mean         sd        +/- sd
time for request:     6.10ms     16.72ms     11.85ms       629us    92.98%
time for connect:     2.06ms     13.07ms      9.24ms      2.86ms    80.00%
time to 1st byte:    18.13ms     29.92ms     24.40ms      3.04ms    80.00%
req/s           :    8315.78     8358.82     8325.25       12.80    90.00%
```

CI after:

```
finished in 827.46ms, 120852.20 req/s, 3.57MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 2.96MB (3100430) total, 97.66KB (100000) headers (space savings 90.00%), 1.14MB (1200000) data
                     min         max         mean         sd        +/- sd
time for request:     2.10ms     12.94ms      8.06ms       415us    95.09%
time for connect:     1.72ms     17.68ms      8.44ms      4.19ms    80.00%
time to 1st byte:     9.38ms     28.34ms     17.93ms      5.77ms    70.00%
req/s           :   12107.28    12269.80    12169.33       50.83    70.00%
```