### PR TITLE
Add server callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ examples/streamClient
 examples/localServer
 examples/dataStream
 examples/tlsServer
+h2spec
 config.nims
 out
 patches

--- a/src/hyperx/client.nim
+++ b/src/hyperx/client.nim
@@ -35,7 +35,8 @@ export
   HyperxStrmError,
   HyperxError,
   isGracefulClose,
-  trace
+  trace,
+  onClose
 
 var sslContext {.threadvar, definedSsl.}: SslContext
 

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -193,8 +193,12 @@ proc close*(client: ClientContext) {.raises: [HyperxConnError].} =
     client.sendBufDrainSig.close()
     if client.onClose != nil:
       client.onClose()
+      client.onClose = nil  # break possible cycle
 
 func onClose*(client: ClientContext, cb: proc () {.closure, gcsafe, raises: [].}) =
+  # XXX onClose can only be called onNewClient (before isConnected);
+  #     after we do not know if the client is closed or not connected yet
+  doAssert not client.isConnected
   doAssert client.onClose == nil
   client.onClose = cb
 

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -191,6 +191,8 @@ proc close*(client: ClientContext) {.raises: [HyperxConnError].} =
     client.windowUpdateSig.close()
     client.sendBufSig.close()
     client.sendBufDrainSig.close()
+    if client.onClose != nil:
+      client.onClose()
 
 func onClose*(client: ClientContext, cb: proc () {.closure, gcsafe, raises: [].}) =
   doAssert client.onClose == nil
@@ -895,8 +897,6 @@ proc shutdown*(client: ClientContext) {.async.} =
   await silent client.dispFut
   await silent client.winupFut
   await silent client.sendFut
-  if client.onClose != nil:
-    client.onClose()
 
 template with*(client: ClientContext, body: untyped): untyped =
   discard getGlobalDispatcher()  # setup event loop

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -169,6 +169,10 @@ type StreamCallback* =
   proc (stream: ClientStream): Future[void] {.closure, gcsafe.}
 type SafeStreamCallback* =
   proc (stream: ClientStream): Future[void] {.nimcall, gcsafe.}
+type ClientCallback* =
+  proc (client: ClientContext): StreamCallback {.closure, gcsafe.}
+type ServerCallback* =
+  proc (client: ClientContext): ClientCallback {.closure, gcsafe.}
 
 proc processStreamHandler(
   strm: ClientStream,
@@ -217,6 +221,22 @@ proc serve*(
       while server.isConnected:
         let client = await server.recvClient()
         await lt.spawn processClientHandler(client, callback)
+  finally:
+    await lt.join()
+
+proc serve*(
+  server: ServerContext,
+  serverCallback: ServerCallback,
+  maxConnections = defaultMaxConns
+) {.async.} =
+  let lt = newLimiter maxConnections
+  try:
+    with server:
+      let clientCallback = serverCallback server
+      while server.isConnected:
+        let client = await server.recvClient()
+        let streamCallback = clientCallback client
+        await lt.spawn processClientHandler(client, streamCallback)
   finally:
     await lt.join()
 

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -36,7 +36,8 @@ export
   HyperxError,
   gracefulClose,
   isGracefulClose,
-  trace
+  trace,
+  onClose
 
 var sslContext {.threadvar, definedSsl.}: SslContext
 

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -172,7 +172,7 @@ type SafeStreamCallback* =
 type ClientCallback* =
   proc (client: ClientContext): StreamCallback {.closure, gcsafe.}
 type ServerCallback* =
-  proc (client: ClientContext): ClientCallback {.closure, gcsafe.}
+  proc (server: ServerContext): ClientCallback {.closure, gcsafe.}
 
 proc processStreamHandler(
   strm: ClientStream,

--- a/src/hyperx/stream.nim
+++ b/src/hyperx/stream.nim
@@ -180,6 +180,7 @@ type
     headersRecvSig*, bodyRecvSig*: SignalAsync
     bodyRecvLen*: int
     error*: ref HyperxStrmError
+    onClose: proc () {.closure, gcsafe, raises: [].}
 
 proc newStream(id: StreamId, peerWindow: int32): Stream {.raises: [].} =
   doAssert peerWindow >= 0
@@ -209,6 +210,12 @@ proc close*(stream: Stream) {.raises: [].} =
   stream.pingSig.close()
   stream.bodyRecvSig.close()
   stream.headersRecvSig.close()
+  if stream.onClose != nil:
+    stream.onClose()
+
+func onClose*(stream: Stream, cb: proc () {.closure, gcsafe, raises: [].}) =
+  doAssert stream.onClose == nil
+  stream.onClose = cb
 
 type StreamsClosedError* = object of QueueClosedError
 


### PR DESCRIPTION
This adds support for passing arguments to the stream callback on client creation.

```nim
proc onNewClient(client: ClientContext, xxx: Xxx): StreamCallback =
  let yyy = newYyy()
  proc (strm: ClientStream): Future[void] =
    streamCallback(strm, xxx, yyy)

proc onNewServer(server: ServerContext): ClientCallback =
  let xxx = newXxx()
  proc (client: ClientContext): StreamCallback =
    onNewClient(client, xxx)

proc serve: Future[void] =
  let server = newServer(...)
  server.serve(onNewServer)
```