### PR TITLE
Max header list size

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -575,8 +575,7 @@ proc processMainStream(client: ClientContext, stream: Stream, frm: Frame) {.asyn
         check value <= stgMaxFrameSize, newConnError(hyxProtocolError)
         client.peerMaxFrameSize = value
       of frmsMaxHeaderListSize:
-        # this is only advisory, do nothing for now.
-        # server may reply a 431 status (request header fields too large)
+        # XXX set client.peerMaxHeaderListSize; initial is infinite
         discard
       else:
         # ignore unknown setting


### PR DESCRIPTION
uncompressed headers can no longer exceed 16KB; well, because of huffman it's possible to get a header equal to the limit + 0.5 (50%); because of the dynamic table it's possible to get a header equal to max header table size (4KB by default); because no compression is possible to get a header equal to max frame size (16KB by default); worst case for all of these is ~2.5x the limit, which is ok.