### PR TITLE
Set window to default size

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Both server and client support data streaming. The [data stream example](https:/
 
 ### Backpressure
 
-Backpressure is based on the http2 spec flow-control. The amount of data a connection can process at a time is bounded by the flow-control window size. The initial window size is set to 256KB. Not calling recv in time will buffer up to window size of data. Use `-d:hyperxWindowSize:65536` to set the size to the http/2 spec default of 64KB. Setting a window smaller than 64KB is not well supported.
+Backpressure is based on the http2 spec flow-control. The amount of data a connection can process at a time is bounded by the flow-control window size. Not calling recv in time will buffer up to window size of data. Setting a window smaller than 64KB is not well supported.
 
 ### Using http/2 in place of WebSockets
 

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -39,7 +39,7 @@ const
   stgDisablePush* = 0'u32
   stgDisablePriority* = 1'u32
 const
-  stgWindowSize* {.intdefine: "hyperxWindowSize".} = stgInitialWindowSize.int
+  stgWindowSize* {.intdefine: "hyperxWindowSize".} = 65_535
   stgServerMaxConcurrentStreams* {.intdefine: "hyperxMaxConcurrentStrms".} = 100
   stgMaxSettingsList* {.intdefine: "hyperxMaxSettingsList".} = 100
   stgMaxHeaderListSize* {.intdefine: "hyperxMaxHeaderListSize".} = 16_384

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -39,7 +39,7 @@ const
   stgDisablePush* = 0'u32
   stgDisablePriority* = 1'u32
 const
-  stgWindowSize* {.intdefine: "hyperxWindowSize".} = 262_144
+  stgWindowSize* {.intdefine: "hyperxWindowSize".} = stgInitialWindowSize.int
   stgServerMaxConcurrentStreams* {.intdefine: "hyperxMaxConcurrentStrms".} = 100
   stgMaxSettingsList* {.intdefine: "hyperxMaxSettingsList".} = 100
   stgMaxHeaderListSize* {.intdefine: "hyperxMaxHeaderListSize".} = 16_384
@@ -1199,6 +1199,7 @@ when isMainModule:
     doAssert stgMaxFrameSize == 16_777_215'u32
     doAssert stgDisablePush == 0'u32
     doAssert stgDisablePriority == 1'u32
-    doAssert stgMaxHeaderListSize == 16_384'u32
+    doAssert stgMaxHeaderListSize == 16_384
+    doAssert stgWindowSize == 65_535
 
   echo "ok"


### PR DESCRIPTION
Related #5. Window size is set to the spec default of 64KB-1. Increasing to 256KB has no effect on big data transfers anymore, because of [write coalescing](https://nitely.github.io/2025/03/28/http-2-write-coalescing.html).