### PR TITLE
Catch all stream errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tests/testclient
 tests/testclientserver
 tests/testserver
 tests/testssloff
+tests/testservercatch
 tests/functional/tserial
 tests/functional/tserialinsecure
 tests/functional/tserver

--- a/hyperx.nimble
+++ b/hyperx.nimble
@@ -27,6 +27,7 @@ task test, "Test":
   exec "nim c -f tests/testssloff.nim"
   # integration tests
   exec "nim c -r -f tests/testclientserver.nim"
+  exec "nim c -r -f tests/testservercatch.nim"
 
 task testexamples, "Test examples":
   exec "nim c -r -f -d:hyperxSanityCheck examples/streamClient.nim"

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -182,9 +182,14 @@ proc processStreamHandler(
   try:
     with strm:
       await callback(strm)
+  except HyperxError:
+    debugErr2 getCurrentException()
+    debugErr getCurrentException()
   except CatchableError:
     debugErr2 getCurrentException()
     debugErr getCurrentException()
+    when defined(hyperxLetItCrash):
+      raise getCurrentException()
 
 proc processClientHandler(
   client: ClientContext,
@@ -222,6 +227,7 @@ proc serve*(
       while server.isConnected:
         let client = await server.recvClient()
         await lt.spawn processClientHandler(client, callback)
+        check lt.error == nil, lt.error
   finally:
     await lt.join()
 
@@ -238,6 +244,7 @@ proc serve*(
         let client = await server.recvClient()
         let streamCallback = clientCallback client
         await lt.spawn processClientHandler(client, streamCallback)
+        check lt.error == nil, lt.error
   finally:
     await lt.join()
 

--- a/src/hyperx/server.nim
+++ b/src/hyperx/server.nim
@@ -182,7 +182,7 @@ proc processStreamHandler(
   try:
     with strm:
       await callback(strm)
-  except HyperxError:
+  except CatchableError:
     debugErr2 getCurrentException()
     debugErr getCurrentException()
 

--- a/tests/functional/tserver.nim
+++ b/tests/functional/tserver.nim
@@ -1,5 +1,6 @@
 {.define: ssl.}
 {.define: hyperxSanityCheck.}
+{.define: hyperxLetItCrash.}
 
 from std/os import getEnv
 from std/strutils import contains

--- a/tests/functional/tserverinsecure.nim
+++ b/tests/functional/tserverinsecure.nim
@@ -1,5 +1,6 @@
 {.define: ssl.}
 {.define: hyperxSanityCheck.}
+{.define: hyperxLetItCrash.}
 
 import std/asyncdispatch
 import ../../src/hyperx/server

--- a/tests/functional/tservermultithread.nim
+++ b/tests/functional/tservermultithread.nim
@@ -1,5 +1,6 @@
 {.define: ssl.}
 {.define: hyperxSanityCheck.}
+{.define: hyperxLetItCrash.}
 
 from std/os import getEnv
 import std/asyncdispatch

--- a/tests/testserver.nim
+++ b/tests/testserver.nim
@@ -1,6 +1,7 @@
 {.define: ssl.}
 {.define: hyperxTest.}
 {.define: hyperxSanityCheck.}
+{.define: hyperxLetItCrash.}
 
 import std/strutils
 import std/asyncdispatch

--- a/tests/testservercatch.nim
+++ b/tests/testservercatch.nim
@@ -7,7 +7,7 @@ import ../src/hyperx/client
 import ../src/hyperx/server
 from ../src/hyperx/errors import hyxCancel
 
-const localPort = Port 8773
+const localPort = Port 8774
 const localHost = "127.0.0.1"
 
 type MyError = object of CatchableError

--- a/tests/testservercatch.nim
+++ b/tests/testservercatch.nim
@@ -1,0 +1,44 @@
+## Test raise error within stream without -d:hyperxLetItCrash
+
+{.define: hyperxSanityCheck.}
+
+import std/asyncdispatch
+import ../src/hyperx/client
+import ../src/hyperx/server
+from ../src/hyperx/errors import hyxCancel
+
+const localPort = Port 8773
+const localHost = "127.0.0.1"
+
+type MyError = object of CatchableError
+
+proc test {.async.} =
+  var checked = 0
+  let server = newServer(
+    localHost, localPort, ssl = false
+  )
+  let serveFut = server.serve(proc (strm: ClientStream) {.async.} =
+    try:
+      raise (ref MyError)()
+    finally:
+      await strm.cancel(hyxCancel)
+      inc checked
+  )
+  let client = newClient(localHost, localPort, ssl = false)
+  with client:
+    try:
+      discard await client.get("/")
+      doAssert false
+    except HyperxStrmError as err:
+      doAssert err.code.int == hyxCancel.int
+  server.close()
+  try:
+    await serveFut
+  except HyperxConnError:
+    discard
+  doAssert checked == 1
+
+discard getGlobalDispatcher()
+waitFor test()
+doAssert not hasPendingOperations()
+echo "ok"


### PR DESCRIPTION
Catch all stream errors, not just HyperxError. The stream handler is asyncCheck'd which terminates the event loop on error. The user can define `hyperxLetItCrash` for the old behavior, useful for tests.