### PR TITLE
Add max headers limit

### DIFF
--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -43,6 +43,7 @@ const
   stgServerMaxConcurrentStreams* {.intdefine: "hyperxMaxConcurrentStrms".} = 100
   stgMaxSettingsList* {.intdefine: "hyperxMaxSettingsList".} = 100
   stgMaxHeaderListSize* {.intdefine: "hyperxMaxHeaderListSize".} = 16_384
+  stgMaxHeaders* {.intdefine: "hyperxMaxHeaders".} = 100
 
 type
   ClientTyp* = enum
@@ -275,6 +276,7 @@ func hpackDecode(
   let L = payload.len
   var canResize = true
   var headerListSize = 0
+  var headersCount = 0
   try:
     while i < L:
       doAssert i > i2; i2 = i
@@ -289,6 +291,8 @@ func hpackDecode(
       else:
         headerListSize += nn.len+vv.len+32
         check headerListSize <= stgMaxHeaderListSize, newConnError(hyxProtocolError)
+        inc headersCount
+        check headersCount <= stgMaxHeaders, newConnError(hyxProtocolError)
         # note this validate headers and trailers
         validateHeader(ss, nn, vv)
         # can resize multiple times before a header, but not after
@@ -1205,5 +1209,6 @@ when isMainModule:
     doAssert stgDisablePriority == 1'u32
     doAssert stgMaxHeaderListSize == 16_384
     doAssert stgWindowSize == 65_535
+    doAssert stgMaxHeaders = 100
 
   echo "ok"

--- a/src/hyperx/clientserver.nim
+++ b/src/hyperx/clientserver.nim
@@ -1209,6 +1209,6 @@ when isMainModule:
     doAssert stgDisablePriority == 1'u32
     doAssert stgMaxHeaderListSize == 16_384
     doAssert stgWindowSize == 65_535
-    doAssert stgMaxHeaders = 100
+    doAssert stgMaxHeaders == 100
 
   echo "ok"

--- a/tests/functional/tmisc.nim
+++ b/tests/functional/tmisc.nim
@@ -295,30 +295,28 @@ testAsync "client onClose":
   doAssert closed == 1
   doAssert checked == 2
 
-testAsync "exceed Max Header List Size":
-  let headerVal = block:
-    var s = ""
-    for _ in 0 ..< 8*1024:
-      s.add 'a'
-    s
-  var headers = defaultHeaders
-  for _ in 0 ..< 20:
-    headers.add ("x-foo", headerVal)
-  var checked = 0
-  var client = newClient(localHost, localPort)
-  with client:
-    let strm = client.newClientStream()
-    with strm:
-      await strm.sendHeaders(headers, finish = true)
-      var data = new string
-      try:
-        await strm.recvHeaders(data)
-        doAssert false
-      except HyperxConnError as err:
-        doAssert err.code == hyxProtocolError
-        inc checked
-    inc checked
-  doAssert checked == 2
+# XXX limited by max headers (100)
+#     it needs header continuation because of frame 16KB limit
+#     to send one big header
+#testAsync "exceed Max Header List Size":
+#  var headers = defaultHeaders
+#  for _ in 0 ..< 8*1024:
+#    headers.add ("x-foo", "foo bar baz qux quz")
+#  var checked = 0
+#  var client = newClient(localHost, localPort)
+#  with client:
+#    let strm = client.newClientStream()
+#    with strm:
+#      await strm.sendHeaders(headers, finish = true)
+#      var data = new string
+#      try:
+#        await strm.recvHeaders(data)
+#        doAssert false
+#      except HyperxConnError as err:
+#        doAssert err.code == hyxProtocolError
+#        inc checked
+#    inc checked
+#  doAssert checked == 2
 
 testAsync "exceed Max Headers":
   var headers = defaultHeaders

--- a/tests/functional/tmisc.nim
+++ b/tests/functional/tmisc.nim
@@ -296,9 +296,34 @@ testAsync "client onClose":
   doAssert checked == 2
 
 testAsync "exceed Max Header List Size":
+  let headerVal = block:
+    var s = ""
+    for _ in 0 ..< 8*1024:
+      s.add 'a'
+    s
   var headers = defaultHeaders
-  for _ in 0 ..< 8*1024:
-    headers.add ("x-foo", "foo bar baz qux quz")
+  for _ in 0 ..< 20:
+    headers.add ("x-foo", headerVal)
+  var checked = 0
+  var client = newClient(localHost, localPort)
+  with client:
+    let strm = client.newClientStream()
+    with strm:
+      await strm.sendHeaders(headers, finish = true)
+      var data = new string
+      try:
+        await strm.recvHeaders(data)
+        doAssert false
+      except HyperxConnError as err:
+        doAssert err.code == hyxProtocolError
+        inc checked
+    inc checked
+  doAssert checked == 2
+
+testAsync "exceed Max Headers":
+  var headers = defaultHeaders
+  for _ in 0 ..< 101:
+    headers.add ("x-foo", "foo")
   var checked = 0
   var client = newClient(localHost, localPort)
   with client:


### PR DESCRIPTION
adds `-d:hyperxMaxHeaders:N` to limit the number of headers.

Currently the only limit is "hyperxMaxHeaderListSize" (byte size of headers after decompression) which limits (indirectly) the max headers to ~1024, but the user may want to increase this to allow big cookies for example which would raise the max headers to a high number.